### PR TITLE
Add dist-size badge and workflow

### DIFF
--- a/.github/workflows/dist-size.yml
+++ b/.github/workflows/dist-size.yml
@@ -1,0 +1,39 @@
+name: dist-size
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress
+      - name: Run dist size check
+        id: dist
+        run: |
+          set +e
+          bin/dist-size-optimizer check --dry-run > /tmp/out.txt
+          exit_code=$?
+          cat /tmp/out.txt
+          if [ $exit_code -eq 0 ]; then
+            echo '{"schemaVersion":1,"label":"dist-size","message":"optimized","color":"brightgreen"}' > dist-size-status.json
+          else
+            echo '{"schemaVersion":1,"label":"dist-size","message":"needs optimization","color":"red"}' > dist-size-status.json
+          fi
+          echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
+      - name: Commit status
+        if: github.event_name == 'push'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore: update dist-size badge [skip ci]'
+          file_pattern: dist-size-status.json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/savinmikhail/EnforceAaaPatternRector/badges/quality-score.png?b=main)](https://scrutinizer-ci.com/g/savinmikhail/EnforceAaaPatternRector/?branch=main)
 [![Code Coverage](https://scrutinizer-ci.com/g/savinmikhail/EnforceAaaPatternRector/badges/coverage.png?b=main)](https://scrutinizer-ci.com/g/savinmikhail/EnforceAaaPatternRector/?branch=main)
+![dist-size status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/savinmikhail/EnforceAaaPatternRector/main/dist-size-status.json)
 
 # EnforceAaaPatternRector
 

--- a/dist-size-status.json
+++ b/dist-size-status.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"dist-size","message":"optimized","color":"brightgreen"}


### PR DESCRIPTION
## Summary
- add dist-size status badge to README
- run dist-size check in GitHub Actions workflow and update status

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/dist-size-optimizer check --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68b82c65eae08324940d2fcfe06cedfc